### PR TITLE
Fix migration autoincrement

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -24,6 +24,7 @@ Infrastructure / Support
 * Dump and restore postgres database as CLI commands [see `PR #68 <https://github.com/SeitaBV/flexmeasures/pull/68>`_]
 * Improved installation tutorial as part of [`PR #54 <http://www.github.com/SeitaBV/flexmeasures/pull/54>`_]
 * Moved developer docs from Readmes into the main documentation  [see `PR #73 <https://github.com/SeitaBV/flexmeasures/pull/73>`_]
+* Ensured unique sensor ids for all sensors [see `PR #70 <https://github.com/SeitaBV/flexmeasures/pull/70>`_ and (fix) `PR #77 <https://github.com/SeitaBV/flexmeasures/pull/77>`_]
 
 
 

--- a/flexmeasures/data/migrations/versions/a528c3c81506_unique_generic_sensor_ids.py
+++ b/flexmeasures/data/migrations/versions/a528c3c81506_unique_generic_sensor_ids.py
@@ -201,10 +201,10 @@ def upgrade_data():
         sa.Column("id", sa.Integer),
     )
     sequence_name = "%s_id_seq" % t_sensors.name
-    # Set table seq to max id of all old sensors combined
+    # Set next id for table seq to just after max id of all old sensors combined
     connection.execute(
         "SELECT setval('%s', %s, true);"
-        % (sequence_name, max_asset_id + max_market_id + max_weather_sensor_id)
+        % (sequence_name, max_asset_id + max_market_id + max_weather_sensor_id + 1)
     )
 
 


### PR DESCRIPTION
Sequence ids contain the next id rather than the current id (and start at 1 rather than 0). For any database that went through revision `a528c3c81506`, I recommend downgrading to `22ce09690d23` and upgrading again to set the right sequence id.

Not doing that isn't particularly problematic for live servers (creating a new sensor would fail exactly once per server). However, running `flexmeasures db upgrade` on an empty database will fail on trying to set the sequence id to 0.