### PR TITLE
Cli csv upload

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -8,8 +8,6 @@ v0.4.0 | April XX, 2021
 
 New features
 -----------
-* Add sensors with CLI command [see `PR #83 <https://github.com/SeitaBV/flexmeasures/pull/83>`_]
-* Add data (beliefs about sensor events) with CLI command [see `PR #85 <https://github.com/SeitaBV/flexmeasures/pull/85>`_]
 * Configure views with ``FLEXMEASURES_LISTED_VIEWS`` [see `PR #91 <https://github.com/SeitaBV/flexmeasures/pull/91>`_]
 * Allow for views and CLI functions to come from plugins [see also `PR #91 <https://github.com/SeitaBV/flexmeasures/pull/91>`_]
 
@@ -21,6 +19,8 @@ Infrastructure / Support
 ----------------------
 * Updated dependencies, including Flask-Security-Too [see `PR #82 <http://www.github.com/SeitaBV/flexmeasures/pull/82>`_]
 * Integration with `timely beliefs <https://github.com/SeitaBV/timely-beliefs>`_ lib: Sensor data as TimedBeliefs [see `PR #79 <http://www.github.com/SeitaBV/flexmeasures/pull/79>`_]
+* Add sensors with CLI command currently meant for developers only [see `PR #83 <https://github.com/SeitaBV/flexmeasures/pull/83>`_]
+* Add data (beliefs about sensor events) with CLI command currently meant for developers only [see `PR #85 <https://github.com/SeitaBV/flexmeasures/pull/85>`_]
 
 
 v0.3.1 | April 9, 2021

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -9,6 +9,7 @@ v0.4.0 | April XX, 2021
 New features
 -----------
 * Add sensors with CLI command [see `PR #83 <https://github.com/SeitaBV/flexmeasures/pull/83>`_]
+* Add data (beliefs about sensor events) with CLI command [see `PR #85 <https://github.com/SeitaBV/flexmeasures/pull/85>`_]
 * Configure views with ``FLEXMEASURES_LISTED_VIEWS`` [see `PR #91 <https://github.com/SeitaBV/flexmeasures/pull/91>`_]
 * Allow for views and CLI functions to come from plugins [see also `PR #91 <https://github.com/SeitaBV/flexmeasures/pull/91>`_]
 

--- a/flexmeasures/data/models/data_sources.py
+++ b/flexmeasures/data/models/data_sources.py
@@ -46,7 +46,7 @@ class DataSource(db.Model, tb.BeliefSourceDBMixin):
             return f"schedule by {self.name}"
         elif self.type == "crawling script":
             return f"data retrieved from {self.name}"
-        elif self.type == "demo script":
+        elif self.type in ("demo script", "CLI script"):
             return f"demo data entered by {self.name}"
         else:
             return f"data from {self.name}"

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -110,17 +110,37 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
         )
 
     @classmethod
-    def add(cls, bdf: tb.BeliefsDataFrame, commit_transaction: bool = True):
+    def add(
+        cls,
+        bdf: tb.BeliefsDataFrame,
+        expunge_session: bool = False,
+        allow_overwrite: bool = False,
+        bulk_save_objects: bool = False,
+        commit_transaction: bool = False,
+    ):
         """Add a BeliefsDataFrame as timed beliefs in the database.
 
         :param bdf: the BeliefsDataFrame to be persisted
-        :param commit_transaction: if True, the session is committed
-                                   if False, you can still add other data to the session
-                                   and commit it all within an atomic transaction
+        :param expunge_session:     if True, all non-flushed instances are removed from the session before adding beliefs.
+                                    Expunging can resolve problems you might encounter with states of objects in your session.
+                                    When using this option, you might want to flush newly-created objects which are not beliefs
+                                    (e.g. a sensor or data source object).
+        :param allow_overwrite:     if True, new objects are merged
+                                    if False, objects are added to the session or bulk saved
+        :param bulk_save_objects:   if True, objects are bulk saved with session.bulk_save_objects(),
+                                    which is quite fast but has several caveats, see:
+                                    https://docs.sqlalchemy.org/orm/persistence_techniques.html#bulk-operations-caveats
+                                    if False, objects are added to the session with session.add_all()
+        :param commit_transaction:  if True, the session is committed
+                                    if False, you can still add other data to the session
+                                    and commit it all within an atomic transaction
         """
         return cls.add_to_session(
             session=db.session,
             beliefs_data_frame=bdf,
+            expunge_session=expunge_session,
+            allow_overwrite=allow_overwrite,
+            bulk_save_objects=bulk_save_objects,
             commit_transaction=commit_transaction,
         )
 

--- a/flexmeasures/data/scripts/cli_tasks/data_add.py
+++ b/flexmeasures/data/scripts/cli_tasks/data_add.py
@@ -255,26 +255,21 @@ def add_beliefs(
         print("SETTING UP CLI SCRIPT AS NEW DATA SOURCE...")
         source = DataSource(name="Seita", type="CLI script")
         db.session.add(source)
-    if horizon is not None:
-        bdf = tb.read_csv(
-            file,
-            sensor,
-            source,
-            belief_horizon=timedelta(minutes=horizon),
-            cumulative_probability=cp,
-            parse_dates=True,
-            infer_datetime_format=True,
-        )
-    else:
-        bdf = tb.read_csv(
-            file,
-            sensor,
-            source,
-            belief_time=server_now().astimezone(pytz.timezone(sensor.timezone)),
-            cumulative_probability=cp,
-            parse_dates=True,
-            infer_datetime_format=True,
-        )
+    bdf = tb.read_csv(
+        file,
+        sensor,
+        source=source,
+        cumulative_probability=cp,
+        parse_dates=True,
+        infer_datetime_format=True,
+        **(
+            dict(belief_horizon=timedelta(minutes=horizon))
+            if horizon is not None
+            else dict(
+                belief_time=server_now().astimezone(pytz.timezone(sensor.timezone))
+            )
+        ),
+    )
     TimedBelief.add(bdf, commit_transaction=False)
     db.session.commit()
     print(f"Successfully created beliefs\n{bdf}")

--- a/flexmeasures/data/scripts/cli_tasks/data_add.py
+++ b/flexmeasures/data/scripts/cli_tasks/data_add.py
@@ -218,7 +218,7 @@ def add_initial_structure():
     "--horizon",
     required=False,
     type=click.IntRange(),
-    help="Belief horizon in minutes (use postive horizon for ex-ante beliefs or negative horizon for ex-post beliefs).",
+    help="Belief horizon in minutes (use positive horizon for ex-ante beliefs or negative horizon for ex-post beliefs).",
 )
 @click.option(
     "--cp",
@@ -244,6 +244,8 @@ def add_beliefs(
         2020-12-03 14:10,215.6
         2020-12-03 14:20,203.8
 
+    In case no --horizon is specified, the moment of executing this CLI command is taken
+    as the time at which the beliefs were recorded.
     """
     sensor = Sensor.query.filter(Sensor.id == sensor_id).one_or_none()
     source = (

--- a/flexmeasures/data/scripts/cli_tasks/data_add.py
+++ b/flexmeasures/data/scripts/cli_tasks/data_add.py
@@ -218,7 +218,7 @@ def add_initial_structure():
 @click.option(
     "--horizon",
     required=False,
-    type=click.IntRange(),
+    type=int,
     help="Belief horizon in minutes (use positive horizon for ex-ante beliefs or negative horizon for ex-post beliefs).",
 )
 @click.option(
@@ -259,6 +259,9 @@ def add_beliefs(
     as the time at which the beliefs were recorded.
     """
     sensor = Sensor.query.filter(Sensor.id == sensor_id).one_or_none()
+    if sensor is None:
+        print(f"Failed to create beliefs: no sensor found with id {sensor_id}.")
+        return
     source = (
         DataSource.query.filter(DataSource.name == "Seita")
         .filter(DataSource.type == "CLI script")

--- a/flexmeasures/data/scripts/cli_tasks/data_add.py
+++ b/flexmeasures/data/scripts/cli_tasks/data_add.py
@@ -29,6 +29,11 @@ def fm_add_data():
     """FlexMeasures: Add data."""
 
 
+@click.group("dev-add")
+def fm_dev_add_data():
+    """Developer CLI commands not yet meant for users: Add data."""
+
+
 @fm_add_data.command("user")
 @with_appcontext
 @click.option("--username", required=True)
@@ -68,7 +73,7 @@ def new_user(username: str, email: str, roles: List[str], timezone: str):
     print(f"Successfully created user {created_user}")
 
 
-@fm_add_data.command("sensor")
+@fm_dev_add_data.command("sensor")
 @with_appcontext
 @click.option("--name", required=True)
 @click.option("--unit", required=True, help="e.g. °C, m/s, kW/m²")
@@ -206,7 +211,7 @@ def add_initial_structure():
     populate_structure(app.db)
 
 
-@fm_add_data.command("beliefs")
+@fm_dev_add_data.command("beliefs")
 @with_appcontext
 @click.argument("file", type=click.Path(exists=True))
 @click.option(
@@ -440,6 +445,7 @@ def collect_weather_data(region, location, num_cells, method, store_in_db):
 
 
 app.cli.add_command(fm_add_data)
+app.cli.add_command(fm_dev_add_data)
 
 
 def check_timezone(timezone):

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -32,7 +32,7 @@ netCDF4
 siphon
 tables
 timetomodel>=0.6.8
-timely-beliefs>=1.3.0
+timely-beliefs>=1.3.1
 python-dotenv
 # a backport, not needed in Python3.8
 importlib_metadata

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -32,7 +32,7 @@ netCDF4
 siphon
 tables
 timetomodel>=0.6.8
-timely-beliefs>=1.3.1
+timely-beliefs>=1.4.0
 python-dotenv
 # a backport, not needed in Python3.8
 importlib_metadata

--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -317,7 +317,7 @@ tables==3.6.1
     # via -r requirements/app.in
 threadpoolctl==2.1.0
     # via scikit-learn
-timely-beliefs==1.3.0
+timely-beliefs==1.4.0
     # via -r requirements/app.in
 timetomodel==0.6.9
     # via -r requirements/app.in


### PR DESCRIPTION
Best reviewed in conjunction with https://github.com/SeitaBV/timely-beliefs/pull/54.

Note that, if the user doesn't set a horizon explicitly, the server time will be used as belief time. Running the CLI command on the same CSV file twice will then work, and ends up storing the same set of values with a different belief horizon.
If the user sets a horizon explicitly, running the CLI command on the same CSV file twice will throw a database error because the data is already there. I tried but was unsuccessful at supporting an `allow_overwrite=True` option, which requires an "upsert" implementation like I had done before for the API in play mode (there I used `session.merge`). If you think it deserves another look, I could share my faulty implementation and maybe you could take a look. Let me know.