### PR TITLE
small doc improvements from user testing

### DIFF
--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -3,6 +3,10 @@
 API change log
 ===============
 
+v2.0 | 2021-04-XX
+"""""""""""""""""
+- [**Breaking change**] Automatic inference of horizons for Post requests re-instantiated, now inferring a belief horizon of zero (leading to the same horizon for each belief).
+
 v2.0 | 2021-04-02
 """""""""""""""""
 

--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -3,16 +3,16 @@
 API change log
 ===============
 
-v2.0 | 2021-04-XX
+v2.0-3 | 2021-04-XX
 """""""""""""""""
-- [**Breaking change**] Automatic inference of horizons for Post requests re-instantiated, now inferring a belief horizon of zero (leading to the same horizon for each belief).
+- Fixed regression by partially reverting one of the breaking changes in v2.0-2: Re-instantiated automatic inference of horizons for Post requests for API versions below v2.0, but changed to inference policy: now inferring the data was recorded **right after each event** took place (leading to a zero horizon for each data point) rather than **after the last event** took place (which led to a different horizon for each data point); the latter had been the inference policy before v2.0-2.
 
-v2.0 | 2021-04-02
+v2.0-2 | 2021-04-02
 """""""""""""""""
 
 - [**Breaking change**] Switched the interpretation of horizons to rolling horizons.
 - [**Breaking change**] Deprecated the use of ISO 8601 repeating time intervals to denote rolling horizons.
-- [**Breaking change**] Deprecated the automatic inference of horizons for *postMeterData*, *postPrognosis*, *postPriceData* and *postWeatherData* endpoints for API version below v2.0.
+- [**Breaking change**, partially reverted in v2.0-3] Deprecated the automatic inference of horizons for *postMeterData*, *postPrognosis*, *postPriceData* and *postWeatherData* endpoints for API version below v2.0.
 - Introduced the "prior" field for *postMeterData*, *postPrognosis*, *postPriceData* and *postWeatherData* endpoints.
 - Changed the Introduction section:
 
@@ -22,12 +22,12 @@ v2.0 | 2021-04-02
 
     - Rewrote relevant examples using horizon and prior fields.
 
-v2.0 | 2021-02-19
+v2.0-1 | 2021-02-19
 """""""""""""""""""
 
 - REST endpoints for managing users: `/users/` (GET), `/user/<id>` (GET, PATCH) and `/user/<id>/password-reset` (PATCH).
 
-v2.0 | 2020-11-14
+v2.0-0 | 2020-11-14
 """""""""""""""""""
 
 - REST endpoints for managing assets: `/assets/` (GET, POST) and `/asset/<id>` (GET, PATCH, DELETE).

--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -169,10 +169,7 @@ v1.1-2 | 2018-08-15
 - Added the *postPriceData* endpoint
 - Added a description of the *postPrognosis* endpoint in the Aggregator section
 - Added a description of the *postPriceData* endpoint in the Aggregator and Supplier sections
-
-.. ifconfig:: FLEXMEASURES_MODE == "play"
-
-    - Added the *restoreData* endpoint
+- Added the *restoreData* endpoint for servers in play mode
 
 v1.1-1 | 2018-08-06
 """""""""""""""""""

--- a/documentation/api/change_log.rst
+++ b/documentation/api/change_log.rst
@@ -1,9 +1,9 @@
-.. _change_log:
+.. _api_change_log:
 
 API change log
 ===============
 
-v2.0 | 2021-03-23
+v2.0 | 2021-04-02
 """""""""""""""""
 
 - [**Breaking change**] Switched the interpretation of horizons to rolling horizons.

--- a/documentation/api/introduction.rst
+++ b/documentation/api/introduction.rst
@@ -257,7 +257,9 @@ In case of a single group of connections, the message may be flattened to:
 Timeseries
 ^^^^^^^^^^
 
-Timestamps and durations are consistent with the ISO 8601 standard. All timestamps in requests to the API must be timezone-aware. The timezone indication "Z" indicates a zero offset from UTC. Additionally, we use the following shorthand for sequential values within a time interval:
+Timestamps and durations are consistent with the ISO 8601 standard. The resolution of the data is implicit, see :ref:`resolutions`.
+
+All timestamps in requests to the API must be timezone-aware. The timezone indication "Z" indicates a zero offset from UTC. Additionally, we use the following shorthand for sequential values within a time interval:
 
 .. code-block:: json
 
@@ -405,8 +407,9 @@ This denotes that the prognosed interval has 5 minutes left to be concluded.
 Resolutions
 ^^^^^^^^^^^
 
-Specifying a resolution is redundant for POST requests that contain both "values" and a "duration".
-Also, posted data is checked against the required resolution of the assets which are posted to.
+Specifying a resolution is redundant for POST requests that contain both "values" and a "duration" ― FlexMeasures computes the resolution by dividing the duration by the number of values.
+
+When POSTing data, FlexMeasures checks this computed resolution against the required resolution of the assets which are posted to. If these can't be matched (through upsampling), an error will occur.
 
 GET requests (such as *getMeterData*) return data in the resolution which the sensor is configured for.
 A "resolution" may be specified explicitly to obtain the data in downsampled form, 

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -16,9 +16,7 @@ Infrastructure / Support
 * Integration with `timely beliefs <https://github.com/SeitaBV/timely-beliefs>`_ lib: Sensor data as TimedBeliefs [see `PR #79 <http://www.github.com/SeitaBV/flexmeasures/pull/79>`_]
 
 
-
-
-v0.2.4 | April 2, 2021
+v0.3.0 | April 2, 2021
 ===========================
 
 New features
@@ -27,7 +25,7 @@ New features
 * Optionally setting recording time when posting data [see `PR #41 <http://www.github.com/SeitaBV/flexmeasures/pull/41>`_]
 * Add assets and weather sensors with CLI commands [see `PR #74 <https://github.com/SeitaBV/flexmeasures/pull/74>`_]
 
-.. note:: Read more on these features on `the FlexMeasures blog <https://flexmeasures.io/v024-pip-install-cli-commands-belief-time-api/>`__.
+.. note:: Read more on these features on `the FlexMeasures blog <https://flexmeasures.io/v030-pip-install-cli-commands-belief-time-api/>`__.
 
 Bugfixes
 --------

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -20,6 +20,7 @@ Infrastructure / Support
 ----------------------
 * Updated dependencies, including Flask-Security-Too [see `PR #82 <http://www.github.com/SeitaBV/flexmeasures/pull/82>`_]
 * Integration with `timely beliefs <https://github.com/SeitaBV/timely-beliefs>`_ lib: Sensor data as TimedBeliefs [see `PR #79 <http://www.github.com/SeitaBV/flexmeasures/pull/79>`_]
+* Improved documentation after user feedback [see `PR #97 <http://www.github.com/SeitaBV/flexmeasures/pull/97>`_]
 
 
 v0.3.1 | April 9, 2021

--- a/documentation/cli/change_log.rst
+++ b/documentation/cli/change_log.rst
@@ -5,7 +5,7 @@ FlexMeasures CLI Changelog
 **********************
 
 
-since v0.2.4 | March XX, 2021
+since v0.3.0 | April 2, 2021
 =====================
 
 * Refactor CLI into the main groups ``add``, ``delete``, ``jobs`` and ``db-ops``

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -26,11 +26,14 @@ Level above which log messages are added to the log file. See the ``logging`` pa
 
 Default: ``logging.WARNING``
 
+
+.. _modes-config:
+
 FLEXMEASURES_MODE
 ^^^^^^^^^^^^^^^^^
 
 The mode in which FlexMeasures is being run, e.g. "demo" or "play".
-This is used to turn on certain extra behaviours.
+This is used to turn on certain extra behaviours, see :ref:`modes-dev` for details.
 
 Default: ``""``
 
@@ -369,12 +372,16 @@ Default: ``None``
 Demonstrations
 --------------
 
+.. _demo-credentials-config:
+
 FLEXMEASURES_PUBLIC_DEMO_CREDENTIALS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When ``FLEXMEASURES_MODE=demo``\ , this can hold login credentials (demo user email and password, e.g. ``("demo at seita.nl", "flexdemo")``\ ), so anyone can log in and try out the platform.
 
 Default: ``None``
+
+.. _demo-year-config:
 
 FLEXMEASURES_DEMO_YEAR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/dev/ci.rst
+++ b/documentation/dev/ci.rst
@@ -9,7 +9,7 @@ Here you can learn how to get FlexMeasures onto a server.
     :local:
     :depth: 1
 
-.. note:: It would be great to enable Dockerization of FlexMeasures, let us know if this matters to you.
+.. todo:: It would be great to enable Dockerization of FlexMeasures, let us know if this matters to you.
 
 WSGI configuration
 ------------------
@@ -22,15 +22,10 @@ Here is an example how to serve FlexMeasures as WSGI app:
    # web application.
    # It works by setting the variable 'application' to a WSGI handler of some description.
 
-   import sys
    import os
    from dotenv import load_dotenv
 
-   # add your project directory to the sys.path
    project_home = u'/path/to/your/code/flexmeasures'
-   if project_home not in sys.path:
-       sys.path = [project_home] + sys.path
-
    load_dotenv(os.path.join(project_home, '.env'))
 
    # create flask app - need to call it "application" for WSGI to work
@@ -64,7 +59,7 @@ In case you want to install a later version, adapt the version in the script.
 Automate deployment via Github actions and Git
 ------------------------------------------------
 
-At FlexMeasures headquarters, we implemented a specifig workflow to automate our deployment. It uses the Github action workflow (see the ``.github/workflows`` directory), which pushes to a remote upstream repository. We use this workflow to build and deploy the project to our staging server.
+At FlexMeasures headquarters, we implemented a specific workflow to automate our deployment. It uses the Github action workflow (see the ``.github/workflows`` directory), which pushes to a remote upstream repository. We use this workflow to build and deploy the project to our staging server.
 
 Documenting this might be useful for self-hosters, as well.
 The GitHub Actions workflows are triggered by commits being pushed to the repository, but it can also inspire your custom deployment script.
@@ -110,7 +105,7 @@ To make this work, we need to configure the following:
 
 
 * Add the deployment server to ``~/.ssh/known_hosts`` of the deployment environment, so that the deployment environment knows it's okay to talk to the deployment server (e.g. ``deploy.yml`` expects it in the Github repository secrets as ``KNOWN_DEPLOYMENT_HOSTS``\ ). You can create this entry with ``ssh-keyscan -t rsa <your host>``.
-* Add the private part of the ssh key pair as key in the deployment environment, so that the deployment server can accept the pushed code. (e.g. as ``~/.ssh/id_rsa``\ ). In ``deploy.yml``\ , we expect it as the secret ``SSH_DEPLOYMENT_KEY``\ , which addds the key for us.
+* Add the private part of the ssh key pair as key in the deployment environment, so that the deployment server can accept the pushed code. (e.g. as ``~/.ssh/id_rsa``\ ). In ``deploy.yml``\ , we expect it as the secret ``SSH_DEPLOYMENT_KEY``\ , which adds the key for us.
 * Finally, the public part of the key pair should be in ``~/.ssh/authorized_keys`` on your deployment server.
 
 

--- a/documentation/dev/data.rst
+++ b/documentation/dev/data.rst
@@ -100,28 +100,7 @@ Or, from within Postgres console:
    CREATE DATABASE flexmeasures_test WITH OWNER = flexmeasures_test;
 
 
-Log in as the postgres superuser and connect to your newly-created database:
-
-.. code-block:: bash
-
-   sudo -u postgres psql
-
-.. code-block:: sql
-
-   \connect flexmeasures
-
-
-Add the following extensions while logged in as the postgres superuser:
-
-.. code-block:: sql
-
-   CREATE EXTENSION cube;
-   CREATE EXTENSION earthdistance;
-
-
-Connect to the ``flexmeasures_test`` database and repeat creating these extensions there. Then ``exit``.
-
-Finally, try logging in as the flexmeasures user once:
+Finally, test if you can log in as the flexmeasures user:
 
 .. code-block:: bash
 
@@ -130,6 +109,26 @@ Finally, try logging in as the flexmeasures user once:
 .. code-block:: sql
 
    \q
+
+
+Add Postgres Extensions to your database(s)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To find the nearest sensors, FlexMeasures needs some extra POstgres support. 
+Add the following extensions while logged in as the postgres superuser:
+
+.. code-block:: bash
+
+   sudo -u postgres psql
+
+.. code-block:: sql
+
+   \connect flexmeasures
+   CREATE EXTENSION cube;
+   CREATE EXTENSION earthdistance;
+
+
+If you have it, connect to the ``flexmeasures_test`` database and repeat creating these extensions there. Then ``exit``.
 
 
 Configure FlexMeasures app for that database

--- a/documentation/dev/modes.rst
+++ b/documentation/dev/modes.rst
@@ -1,0 +1,41 @@
+.. _modes-dev:
+
+Modes
+============
+
+FlexMeasures can be run in specific modes (see the :ref:`modes-config` config setting).
+This is useful for certain special situations. Two are supported out of the box and we document here 
+how FlexMeasures behaves differently in these modes.
+
+Demo
+-------
+
+In this mode, the server is assumed to be used as a demonstration tool. Most of the following adaptations therefore happen in the UI. 
+
+- [Data] Demo data is often from an older source, and it's a hassle to change the year to the current year. FlexMeasures allows to set :ref:`demo-year-config` and when in ``demo`` mode, the current year will be translated to that year in the background.   
+- [UI] Logged-in users can view queues on the demo server (usually only admins can do that)
+- [UI] Demo servers often display login credentials, so visitors can try out functionality. Use the :ref:`demo-credentials-config` config setting to do this.
+- [UI] The dashboard shows all non-empty asset groups, instead of only the ones for the current user.
+- [UI] The analytics page mocks confidence intervals around power, price and weather data, so that the demo data doesn't need to have them. 
+- [UI] The portfolio page mocks flexibility numbers and a mocked control action.
+
+Play
+------
+
+In this mode, the server is assumed to be used to run simulations.
+
+Big features
+^^^^^^^^^^^^^
+
+- [Data] Allows overwriting existing data when saving data to the database.
+- [API] The inferred recording time of incoming data is immediately after the event took place, rather than the actual time at which the server received the data.
+- [API] Posting price or weather data does not trigger forecasting jobs.
+- [API] The ``restoreData`` endpoint is registered, enabling database resets through the API.
+- [API] When posting weather data for a new location, a new weather sensor is automatically created, instead of returning the nearest available weather sensor to post data to.
+
+Small features
+^^^^^^^^^^^^^^^
+
+- [API] Posted UDI events are not enforced to be consecutive.
+- [API] Names in ``GetConnectionResponse`` are the connections' unique database names rather than their display names (this feature is planned to be deprecated).
+- [UI] The dashboard plot showing the latest power value is not enforced to lie in the past (in case of simulating future values).

--- a/documentation/dev/plugins.rst
+++ b/documentation/dev/plugins.rst
@@ -77,3 +77,20 @@ All else that is needed for this showcase (not shown here) is ``<some_folder>/ou
 
 
 .. note:: Plugin views can also be added to the FlexMeasures UI menu ― just name them in the config setting :ref:`menu-config`.
+
+
+Using other files in your plugin
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Say you want to include other Python files in your plugin, importing them in your ``__init__.py`` file.
+This can be done if you put the plugin path on the import path. Do it like this in your ``__init__.py``:
+
+.. code-block:: python
+
+    import os
+    import sys
+
+    HERE = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, HERE)
+
+    from my_other_file import my_function

--- a/documentation/getting-started.rst
+++ b/documentation/getting-started.rst
@@ -17,6 +17,7 @@ Install dependencies and the ``flexmeasures`` platform itself:
 
    pip install flexmeasures
 
+.. note:: With newer Python versions and Windows, some smaller dependencies (e.g. ``tables`` or ``rq-win``) might cause issues as support is often slower. You might overcome this with a little research, by `installing from wheels <http://www.pytables.org/usersguide/installation.html#prerequisitesbininst>`_ or `from the repo <https://github.com/michaelbrooks/rq-win#installation-and-use>`_, respectively.
 
 
 Make a secret key for sessions and password salts
@@ -217,7 +218,7 @@ To collect weather measurements and forecasts from the DarkSky API, there is a t
 
    flexmeasures add external-weather-forecasts --location 33.4366,126.5269 --store-in-db 
 
-.. note::  DarkSky is not handing out tokens anymore, as they have been bought by Apple (see `issue 3 <https://github.com/SeitaBV/flexmeasures/issues/56>`_).
+.. note::  DarkSky is not handing out tokens any more, as they have been bought by Apple (see `issue 3 <https://github.com/SeitaBV/flexmeasures/issues/56>`_).
 
 
 Preparing the job queue database and start workers

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -85,6 +85,7 @@ The platform operator of FlexMeasures can be an Aggregator.
     dev/api
     dev/ci
     dev/plugins
+    dev/modes
 
 .. toctree::
     :caption: Integrations

--- a/flexmeasures/api/common/responses.py
+++ b/flexmeasures/api/common/responses.py
@@ -64,7 +64,7 @@ def invalid_domain(message: str) -> ResponseTuple:
     return dict(result="Rejected", status="INVALID_DOMAIN", message=message), 400
 
 
-@BaseMessage("The prognosis horizon in your request could not be parsed.")
+@BaseMessage("The horizon field in your request could not be parsed.")
 def invalid_horizon(message: str) -> ResponseTuple:
     return dict(result="Rejected", status="INVALID_HORIZON", message=message), 400
 

--- a/flexmeasures/api/common/responses.py
+++ b/flexmeasures/api/common/responses.py
@@ -86,7 +86,7 @@ def invalid_ptu_duration(message: str) -> ResponseTuple:
     )
 
 
-@BaseMessage("Only the following resolutions are supported:")
+@BaseMessage("Only the following resolutions in the data are supported:")
 def unapplicable_resolution(message: str) -> ResponseTuple:
     return dict(result="Rejected", status="INVALID_RESOLUTION", message=message), 400
 

--- a/flexmeasures/api/common/utils/validators.py
+++ b/flexmeasures/api/common/utils/validators.py
@@ -306,7 +306,7 @@ def optional_prior_accepted(ex_post: bool = False, infer_missing: bool = True):
 
     Optionally, an ex_post flag can be passed to the decorator to indicate that only ex-post datetimes are allowed.
     As a useful setting (at least for POST requests), set infer_missing to True to have servers
-    (that are not in play mode) derive a prior from the server time.
+    derive a prior from the server time.
     """
 
     def wrapper(fn):
@@ -332,11 +332,8 @@ def optional_prior_accepted(ex_post: bool = False, infer_missing: bool = True):
                     if prior < knowledge_time:
                         extra_info = "Meter data can only be observed after the fact."
                         return invalid_horizon(extra_info)
-            elif (
-                infer_missing is True
-                and current_app.config.get("FLEXMEASURES_MODE", "") != "play"
-            ):
-                # A missing prior is inferred by the server (if not in play mode)
+            elif infer_missing is True:
+                # A missing prior is inferred by the server
                 prior = server_now()
             else:
                 # Otherwise, a missing prior is fine (a horizon may still be inferred by the server)
@@ -377,7 +374,7 @@ def optional_horizon_accepted(  # noqa C901
             return 'Meter data posted'
 
     :param ex_post:                   if True, only non-positive horizons are allowed.
-    :param infer_missing:             if True, servers that are in play mode assume that the belief_horizon of posted
+    :param infer_missing:             if True, servers assume that the belief_horizon of posted
                                       values is 0 hours. This setting is meant to be used for POST requests.
     :param accept_repeating_interval: if True, the "rolling" keyword param is also set
                                       (this was used for POST requests before v2.0)
@@ -410,11 +407,8 @@ def optional_horizon_accepted(  # noqa C901
                         "For example: R/P1D should be replaced by P1D."
                     )
                     return invalid_horizon(extra_info)
-            elif (
-                infer_missing is True
-                and current_app.config.get("FLEXMEASURES_MODE", "") == "play"
-            ):
-                # A missing horizon is set to zero for servers in play mode
+            elif infer_missing is True:
+                # A missing horizon is set to zero
                 horizon = timedelta(hours=0)
             elif infer_missing is True and accept_repeating_interval is True:
                 extra_info = "Missing horizons are no longer accepted for API versions below v2.0."

--- a/flexmeasures/api/common/utils/validators.py
+++ b/flexmeasures/api/common/utils/validators.py
@@ -410,9 +410,6 @@ def optional_horizon_accepted(  # noqa C901
             elif infer_missing is True:
                 # A missing horizon is set to zero
                 horizon = timedelta(hours=0)
-            elif infer_missing is True and accept_repeating_interval is True:
-                extra_info = "Missing horizons are no longer accepted for API versions below v2.0."
-                return invalid_horizon(extra_info)
             else:
                 # Otherwise, a missing horizon is fine (a prior may still be inferred by the server)
                 horizon = None

--- a/flexmeasures/api/v1/implementations.py
+++ b/flexmeasures/api/v1/implementations.py
@@ -97,7 +97,9 @@ def get_meter_data_response(
 @units_accepted("power", "MW")
 @assets_required("connection")
 @values_required
-@optional_horizon_accepted(ex_post=True, accept_repeating_interval=True)
+@optional_horizon_accepted(
+    ex_post=True, infer_missing=True, accept_repeating_interval=True
+)
 @period_required
 @post_data_checked_for_required_resolution("connection")
 @as_json

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -46,8 +46,16 @@ from flexmeasures.utils.entity_address_utils import (
 @type_accepted("PostPriceDataRequest")
 @units_accepted("price", "EUR/MWh", "KRW/kWh")
 @assets_required("market")
-@optional_horizon_accepted()
-@optional_prior_accepted()
+@optional_horizon_accepted(
+    infer_missing=True
+    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
+    else False
+)
+@optional_prior_accepted(
+    infer_missing=False
+    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
+    else True
+)
 @values_required
 @period_required
 @post_data_checked_for_required_resolution("market")
@@ -130,8 +138,16 @@ def post_price_data_response(  # noqa C901
 @type_accepted("PostWeatherDataRequest")
 @unit_required
 @assets_required("sensor")
-@optional_horizon_accepted()
-@optional_prior_accepted()
+@optional_horizon_accepted(
+    infer_missing=True
+    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
+    else False
+)
+@optional_prior_accepted(
+    infer_missing=False
+    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
+    else True
+)
 @values_required
 @period_required
 @post_data_checked_for_required_resolution("sensor")
@@ -222,8 +238,18 @@ def post_weather_data_response(  # noqa: C901
 @units_accepted("power", "MW")
 @assets_required("connection")
 @values_required
-@optional_horizon_accepted(ex_post=True)
-@optional_prior_accepted(ex_post=True)
+@optional_horizon_accepted(
+    ex_post=True,
+    infer_missing=True
+    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
+    else False,
+)
+@optional_prior_accepted(
+    ex_post=True,
+    infer_missing=False
+    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
+    else True,
+)
 @period_required
 @post_data_checked_for_required_resolution("connection")
 @as_json
@@ -254,8 +280,13 @@ def post_meter_data_response(
 @units_accepted("power", "MW")
 @assets_required("connection")
 @values_required
-@optional_horizon_accepted(ex_post=False)
-@optional_prior_accepted(ex_post=False)
+@optional_horizon_accepted(ex_post=False, infer_missing=False)
+@optional_prior_accepted(
+    ex_post=False,
+    infer_missing=False
+    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
+    else True,
+)
 @period_required
 @post_data_checked_for_required_resolution("connection")
 @as_json

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -46,16 +46,8 @@ from flexmeasures.utils.entity_address_utils import (
 @type_accepted("PostPriceDataRequest")
 @units_accepted("price", "EUR/MWh", "KRW/kWh")
 @assets_required("market")
-@optional_horizon_accepted(
-    infer_missing=True
-    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
-    else False
-)
-@optional_prior_accepted(
-    infer_missing=False
-    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
-    else True
-)
+@optional_horizon_accepted(infer_missing=None)
+@optional_prior_accepted(infer_missing=None)
 @values_required
 @period_required
 @post_data_checked_for_required_resolution("market")
@@ -138,16 +130,8 @@ def post_price_data_response(  # noqa C901
 @type_accepted("PostWeatherDataRequest")
 @unit_required
 @assets_required("sensor")
-@optional_horizon_accepted(
-    infer_missing=True
-    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
-    else False
-)
-@optional_prior_accepted(
-    infer_missing=False
-    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
-    else True
-)
+@optional_horizon_accepted(infer_missing=None)
+@optional_prior_accepted(infer_missing=None)
 @values_required
 @period_required
 @post_data_checked_for_required_resolution("sensor")
@@ -238,17 +222,10 @@ def post_weather_data_response(  # noqa: C901
 @units_accepted("power", "MW")
 @assets_required("connection")
 @values_required
-@optional_horizon_accepted(
-    ex_post=True,
-    infer_missing=True
-    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
-    else False,
-)
+@optional_horizon_accepted(ex_post=True, infer_missing=None)
 @optional_prior_accepted(
     ex_post=True,
-    infer_missing=False
-    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
-    else True,
+    infer_missing=None,
 )
 @period_required
 @post_data_checked_for_required_resolution("connection")
@@ -283,9 +260,7 @@ def post_meter_data_response(
 @optional_horizon_accepted(ex_post=False, infer_missing=False)
 @optional_prior_accepted(
     ex_post=False,
-    infer_missing=False
-    if current_app.config.get("FLEXMEASURES_MODE", "") == "play"
-    else True,
+    infer_missing=None,
 )
 @period_required
 @post_data_checked_for_required_resolution("connection")

--- a/flexmeasures/api/v2_0/implementations/sensors.py
+++ b/flexmeasures/api/v2_0/implementations/sensors.py
@@ -46,8 +46,8 @@ from flexmeasures.utils.entity_address_utils import (
 @type_accepted("PostPriceDataRequest")
 @units_accepted("price", "EUR/MWh", "KRW/kWh")
 @assets_required("market")
-@optional_horizon_accepted(infer_missing=None)
-@optional_prior_accepted(infer_missing=None)
+@optional_horizon_accepted(infer_missing=False, infer_missing_play=True)
+@optional_prior_accepted(infer_missing=True, infer_missing_play=False)
 @values_required
 @period_required
 @post_data_checked_for_required_resolution("market")
@@ -130,8 +130,8 @@ def post_price_data_response(  # noqa C901
 @type_accepted("PostWeatherDataRequest")
 @unit_required
 @assets_required("sensor")
-@optional_horizon_accepted(infer_missing=None)
-@optional_prior_accepted(infer_missing=None)
+@optional_horizon_accepted(infer_missing=False, infer_missing_play=True)
+@optional_prior_accepted(infer_missing=True, infer_missing_play=False)
 @values_required
 @period_required
 @post_data_checked_for_required_resolution("sensor")
@@ -222,11 +222,8 @@ def post_weather_data_response(  # noqa: C901
 @units_accepted("power", "MW")
 @assets_required("connection")
 @values_required
-@optional_horizon_accepted(ex_post=True, infer_missing=None)
-@optional_prior_accepted(
-    ex_post=True,
-    infer_missing=None,
-)
+@optional_horizon_accepted(ex_post=True, infer_missing=False, infer_missing_play=True)
+@optional_prior_accepted(ex_post=True, infer_missing=True, infer_missing_play=False)
 @period_required
 @post_data_checked_for_required_resolution("connection")
 @as_json
@@ -257,11 +254,8 @@ def post_meter_data_response(
 @units_accepted("power", "MW")
 @assets_required("connection")
 @values_required
-@optional_horizon_accepted(ex_post=False, infer_missing=False)
-@optional_prior_accepted(
-    ex_post=False,
-    infer_missing=None,
-)
+@optional_horizon_accepted(ex_post=False, infer_missing=False, infer_missing_play=False)
+@optional_prior_accepted(ex_post=False, infer_missing=True, infer_missing_play=False)
 @period_required
 @post_data_checked_for_required_resolution("connection")
 @as_json

--- a/flexmeasures/data/scripts/cli_tasks/data_add.py
+++ b/flexmeasures/data/scripts/cli_tasks/data_add.py
@@ -230,14 +230,14 @@ def add_initial_structure():
     multiple=True,
     type=click.Choice(["1", "6", "24", "48"]),
     default=["1", "6", "24", "48"],
-    help="Forecasting horizon in hours. This argument can be given multiple times.",
+    help="Forecasting horizon in hours. This argument can be given multiple times. Defaults to all possible horizons.",
 )
 @click.option(
     "--as-job",
     is_flag=True,
     help="Whether to queue a forecasting job instead of computing directly."
     " Useful to run locally and create forecasts on a remote server. In that case, just point the redis db in your"
-    " config settings to that of the remote server. To process the job, run a worker to process the forecasting queue.",
+    " config settings to that of the remote server. To process the job, run a worker to process the forecasting queue. Defaults to False.",
 )
 def create_forecasts(
     asset_type: str = None,

--- a/flexmeasures/data/services/time_series.py
+++ b/flexmeasures/data/services/time_series.py
@@ -257,6 +257,9 @@ def convert_query_window_for_demo(
             end = (query_window[-1] + timedelta(days=1)).replace(year=demo_year)
         else:
             end = query_window[-1]
+
+    if start >= end:
+        start, end = (end, start)
     return start, end
 
 

--- a/flexmeasures/ui/utils/plotting_utils.py
+++ b/flexmeasures/ui/utils/plotting_utils.py
@@ -564,7 +564,11 @@ def get_latest_power_as_plot(asset: Asset, small: bool = False) -> Tuple[str, st
     First returned string is the measurement time, second string is the html string."""
 
     if current_app.config.get("FLEXMEASURES_MODE", "") == "demo":
-        before = server_now().replace(year=2015)
+        demo_year = current_app.config.get("FLEXMEASURES_DEMO_YEAR", None)
+        if demo_year is None:
+            before = server_now()
+        else:
+            before = server_now().replace(year=demo_year)
     elif current_app.config.get("FLEXMEASURES_MODE", "") == "play":
         before = None  # type:ignore
     else:

--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -131,7 +131,7 @@ def set_time_range_for_session():
                 .astimezone(time_utils.get_timezone())
             )
 
-    # Our demo server works only with the current year's data
+    # Our demo server's UI should only work with the current year's data
     if current_app.config.get("FLEXMEASURES_MODE", "") == "demo":
         session["start_time"] = session["start_time"].replace(year=datetime.now().year)
         session["end_time"] = session["end_time"].replace(year=datetime.now().year)

--- a/flexmeasures/utils/app_utils.py
+++ b/flexmeasures/utils/app_utils.py
@@ -76,7 +76,7 @@ def register_plugins(app: Flask):
     - Your plugin folders contains an __init__.py file.
     - In this init, you define a Blueprint object called <plugin folder>_bp
 
-    We'll refer to the plugins with the name of your plugin folders (last part of tthe path).
+    We'll refer to the plugins with the name of your plugin folders (last part of the path).
     """
     plugin_paths = app.config.get("FLEXMEASURES_PLUGIN_PATHS", "")
     if not isinstance(plugin_paths, list):

--- a/to_pypi.sh
+++ b/to_pypi.sh
@@ -8,24 +8,24 @@
 # The version comes from setuptools_scm. See `python setup.py --version`.
 # setuptools_scm works via git tags that should implement a semantic versioning scheme, e.g. v0.2.3
 #
-# If there were zero commits since since tag, we have a real release and the version basicaly *is* what the tag says.
-# Otherwise, the version also include a .devN identifier, where N is the number of commits since the last version tag.
+# If there were zero commits since since tag, we have a real release and the version basically *is* what the tag says.
+# Otherwise, the version also includes a .devN identifier, where N is the number of commits since the last version tag.
 #
 # More information on creating a dev release
 # -------------------------------------------
 # Note that the only way to create a new dev release is to add another commit on your development branch.
-# It might have been convenient to not have to commit to do that (for exoerimenting with very small changes),
+# It might have been convenient to not have to commit to do that (for experimenting with very small changes),
 # but we decided against that. Let's explore why for a bit:
 #
 # First, setuptools_scm has the ability to add a local scheme (git commit and date/time) to the version,
 # but we've disabled that, as that extra part isn't formatted in a way that Pypi accepts it.
-# Another way would have been to add a local version identifier ("+M", not the plus sign),
+# Another way would have been to add a local version identifier ("+M", note the plus sign),
 # which is allowed in PEP 440 but explicitly disallowed by Pypi.
 # Finally, if we simply add a number to .devN (-> .devNM), the ordering of dev versions would be
 # disturbed after the next local commit (e.g. we add 1 to .dev4, making it .dev41, and then the next version, .dev5,
 # is not the highest version chosen by PyPi).
 # 
-# So we'll use these tools as the experts intend us to.
+# So we'll use these tools as the experts intended.
 # If you want, you can read more about acceptable versions in PEP 440: https://www.python.org/dev/peps/pep-0440/
 
 


### PR DESCRIPTION
Some comments which came from a user conversation today.

I also wonder about one more thing I cannot judge by myself: The `horizon` parameter is not considered optional any more for some API versions < v2 (under some circumstances), but the docstring still list it under \*\*Optional fields\*\* (`v1/routes.py::post_meter_data`). Even the validator is called `optional_horizon_accepted` but I'm not sure if that paints the real picture by now or could be more clear.