### PR TITLE
Move user name from title to menu item (account)

### DIFF
--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -63,13 +63,12 @@
                     <span class="icon-bar"></span>
                 </button>
                 <span class="navbar-brand">
-                    <a href="/"><span class="navbar-tool-name">{{ FLEXMEASURES_PLATFORM_NAME }}</span></a>
-                    {{ self.title() }} {% if user_is_logged_in and not "Error" in self.title() %} for {{ user_name }} {% endif %}
+                    <a href="/"><span class="navbar-tool-name">{{ FLEXMEASURES_PLATFORM_NAME }} {% if not "Error" in self.title() %} - {{ self.title() }} {% endif %}</span></a>
                 </span>
             </div>
             <div class="collapse navbar-collapse  navbar-right" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav">
-                    {% for href, id, caption, icon in navigation_bar %}
+                    {% for href, id, caption, tooltip, icon in navigation_bar %}
                     {% if id == "tasks" %}
                     <li {% if id == active_page %} class="active" {% endif %} class="dropdown">
                         <a class="dropdown-toggle" data-toggle="dropdown" href="#"><span class="fa fa-tasks"
@@ -95,7 +94,7 @@
                         </ul>
                     </li>
                     {% else %}
-                    <li {% if id == active_page %} class="active" {% endif %}
+                    <li {% if id == active_page %} class="active" {% endif %} data-toggle="tooltip" title="{{ tooltip }}" data-placement="bottom"
                         {% if id == 'upload' or (current_user.has_role('anonymous') and id in ('tasks', 'users', 'control', 'portfolio')) %}
                         class="disabled" {% endif %}>
                         <a {% if not ( id == 'upload' or (current_user.has_role('anonymous') and id in ('tasks', 'users', 'control', 'portfolio')) ) %}href="/{{ href|e }}"

--- a/flexmeasures/ui/templates/base.html
+++ b/flexmeasures/ui/templates/base.html
@@ -101,6 +101,12 @@
                             {% endif %}{% if id == 'docs' %} target="_blank" {% endif %}>
                             <span class="fa fa-{{ icon }}" aria-hidden="true"></span>
                             {{ caption|e }}
+
+                            {# use tooltip as caption for small screens #}
+                            {% if not caption %}
+                            <span class="visible-xs-inline">{{ tooltip }}</span>
+                            {% endif %}
+
                         </a>
                     </li>
                     {% endif %}

--- a/flexmeasures/ui/templates/defaults.jinja
+++ b/flexmeasures/ui/templates/defaults.jinja
@@ -21,20 +21,20 @@
 
 {% for view_name in FLEXMEASURES_LISTED_VIEWS %}
     {# add specs for views we don't know (plugin views) #}
-    {% do nav_bar_specs.update({view_name: dict(title=view_name.capitalize(), icon="info")}) if view_name not in nav_bar_specs %}
+    {% do nav_bar_specs.update({view_name: dict(title=view_name.capitalize(), tooltip="", icon="info")}) if view_name not in nav_bar_specs %}
     {# add view to menu if user is authenticated #}
     {% do navigation_bar.append(
-        (view_name, view_name, nav_bar_specs[view_name]["title"], nav_bar_specs[view_name]["icon"])
+        (view_name, view_name, nav_bar_specs[view_name]["title"], nav_bar_specs[view_name]["tooltip"], nav_bar_specs[view_name]["icon"])
     ) if current_user.is_authenticated %}
 {% endfor %}
 
 
 {% set show_queues = True if current_user.is_authenticated and (current_user.has_role('admin') or FLEXMEASURES_MODE == "demo") else False %}
-{% do navigation_bar.append(('tasks', 'tasks', 'Tasks', 'tasks')) if show_queues %}
+{% do navigation_bar.append(('tasks', 'tasks', 'Tasks', '', 'tasks')) if show_queues %}
 
-{% do navigation_bar.append(('account', 'account', '', 'user')) if current_user.is_authenticated %}
+{% do navigation_bar.append(('account', 'account', '', user_name, 'user')) if current_user.is_authenticated %}
 
-{% do navigation_bar.append(('ui/static/documentation/html/index.html', 'docs', '', 'question')) if documentation_exists and current_user.is_authenticated %}
+{% do navigation_bar.append(('ui/static/documentation/html/index.html', 'docs', '', 'Documentation (new window)', 'question')) if documentation_exists and current_user.is_authenticated %}
 
 {% set active_page = active_page|default('dashboard') -%}
 

--- a/flexmeasures/ui/tests/test_views.py
+++ b/flexmeasures/ui/tests/test_views.py
@@ -54,7 +54,7 @@ def test_analytics_responds(db, client, setup_assets, as_prosumer):
     user_datastore = SQLAlchemySessionUserDatastore(db.session, User, Role)
     test_prosumer = user_datastore.find_user(email="test_prosumer@seita.nl")
 
-    assert str.encode(f"for {test_prosumer.username}") in analytics.data
+    assert str.encode(f"{test_prosumer.username}") in analytics.data
 
 
 def test_logout(client, as_prosumer):


### PR DESCRIPTION
We should also use fewer different font styles. This gets rid of one.

Before:

![image](https://user-images.githubusercontent.com/30658763/126178060-b68906f1-cd7d-4270-b370-d886513edcf5.png)


After:

![image](https://user-images.githubusercontent.com/30658763/126177781-d78e21c8-e208-41f3-a1a1-68f771a54b95.png)
