### PR TITLE
Clarify versioning blueprints in plugins

### DIFF
--- a/flexmeasures/ui/utils/view_utils.py
+++ b/flexmeasures/ui/utils/view_utils.py
@@ -71,9 +71,9 @@ def render_flexmeasures_template(html_filename: str, **variables):
     ) = get_git_description()
     app_start_time = current_app.config.get("START_TIME")
     variables["app_running_since"] = time_utils.naturalized_datetime_str(app_start_time)
-    variables["loaded_plugins"] = ",".join(
-        f"{p_name} (v{p_version})"
-        for p_name, p_version in current_app.config.get("LOADED_PLUGINS", {}).items()
+    variables["loaded_plugins"] = ", ".join(
+        f"{p_name} ({'v' + [v for v in p_bp_dict.values()][0] if len(p_bp_dict) == 1 else ', '.join(bp_name + ' v' + bp_version for bp_name, bp_version in p_bp_dict.items())})"
+        for p_name, p_bp_dict in current_app.config.get("LOADED_PLUGINS", {}).items()
     )
 
     variables["user_is_logged_in"] = current_user.is_authenticated

--- a/flexmeasures/utils/app_utils.py
+++ b/flexmeasures/utils/app_utils.py
@@ -205,7 +205,7 @@ def register_plugins(app: Flask):
         spec.loader.exec_module(module)
 
         # Look for blueprints in the plugin's main __init__ module and register them
-        plugin_blueprints = [
+        plugin_blueprints: List[Blueprint] = [
             getattr(module, a)
             for a in dir(module)
             if isinstance(getattr(module, a), Blueprint)
@@ -215,10 +215,12 @@ def register_plugins(app: Flask):
                 f"No blueprints found for plugin {plugin_name} at {plugin_path}."
             )
             continue
+        blueprint_dict = {}
         for plugin_blueprint in plugin_blueprints:
             app.register_blueprint(plugin_blueprint)
-
-        plugin_version = getattr(plugin_blueprint, "__version__", "0.1")
-        app.config["LOADED_PLUGINS"][plugin_name] = plugin_version
+            blueprint_name = plugin_blueprint.name
+            plugin_version = getattr(plugin_blueprint, "__version__", "0.1")
+            blueprint_dict[blueprint_name] = plugin_version
+    app.config["LOADED_PLUGINS"][plugin_name] = blueprint_dict
     app.logger.info(f"Loaded plugins: {app.config['LOADED_PLUGINS']}")
     sentry_sdk.set_context("plugins", app.config.get("LOADED_PLUGINS", {}))


### PR DESCRIPTION
Make it clear that plugins version blueprints, and, in case there are multiple blueprints, show the blueprint versions in the UI footer.

In case of a plugin with a single blueprint, it shows up as `<plugin name> (v<blueprint_version>))` (the blueprint version is reported as the plugin version, which was the behaviour we had before):
![image](https://user-images.githubusercontent.com/30658763/131680499-6b7a9f03-06a3-4196-95d4-29eb35323f61.png)
In case of a plugin with multiple blueprints, it shows up as `<plugin name> (<blueprint_name> v<blueprint_version>))`:
![image](https://user-images.githubusercontent.com/30658763/131680740-9fea7298-e462-4035-a71c-88da19daf00a.png)