### PR TITLE
try foreasting and scheduling jobs for up to one day

### DIFF
--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -23,6 +23,7 @@ Infrastructure / Support
 * Set default timezone for new users using the FLEXMEASURES_TIMEZONE config setting [see `PR #190 <http://www.github.com/SeitaBV/flexmeasures/pull/190>`_]
 * Monitored CLI tasks can get better names for identification [see `PR #193 <http://www.github.com/SeitaBV/flexmeasures/pull/193>`_]
 * Less custom logfile location, document logging for devs [see `PR #196 <http://www.github.com/SeitaBV/flexmeasures/pull/196>`_]
+* Keep forecasting and scheduling jobs in the queues for only up to one day [see `PR #198 <http://www.github.com/SeitaBV/flexmeasures/pull/198>`_]
 
 
 v0.6.1 | September XX, 2021

--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -207,6 +207,16 @@ Timezone in which the platform operates. This is useful when datetimes are being
 
 Default: ``"Asia/Seoul"``
 
+
+FLEXMEASURES_JOB_TTL
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Time to live for jobs (e.g. forecasting, scheduling) in their respective queue.
+
+A job that is passed this time to live might get cleaned out by Redis' memory manager.
+
+Default: ``timedelta(days=1)``
+
 FLEXMEASURES_PLANNING_TTL
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -108,7 +108,11 @@ def create_forecasting_jobs(
                 custom_model_params=custom_model_params,
             ),
             connection=current_app.queues["forecasting"].connection,
-            ttl=24 * 60 * 60,  # try up to one day
+            ttl=int(
+                current_app.config.get(
+                    "FLEXMEASURES_JOB_TTL", timedelta(-1)
+                ).total_seconds()
+            ),
         )
         job.meta["model_search_term"] = model_search_term
         job.save_meta()

--- a/flexmeasures/data/services/forecasting.py
+++ b/flexmeasures/data/services/forecasting.py
@@ -108,6 +108,7 @@ def create_forecasting_jobs(
                 custom_model_params=custom_model_params,
             ),
             connection=current_app.queues["forecasting"].connection,
+            ttl=24 * 60 * 60,  # try up to one day
         )
         job.meta["model_search_term"] = model_search_term
         job.save_meta()

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -64,7 +64,11 @@ def create_scheduling_job(
         ),
         id=udi_event_ea,
         connection=current_app.queues["scheduling"].connection,
-        ttl=24 * 60 * 60,  # try up to one day
+        ttl=int(
+            current_app.config.get(
+                "FLEXMEASURES_JOB_TTL", timedelta(-1)
+            ).total_seconds()
+        ),
         result_ttl=int(
             current_app.config.get(
                 "FLEXMEASURES_PLANNING_TTL", timedelta(-1)

--- a/flexmeasures/data/services/scheduling.py
+++ b/flexmeasures/data/services/scheduling.py
@@ -64,6 +64,7 @@ def create_scheduling_job(
         ),
         id=udi_event_ea,
         connection=current_app.queues["scheduling"].connection,
+        ttl=24 * 60 * 60,  # try up to one day
         result_ttl=int(
             current_app.config.get(
                 "FLEXMEASURES_PLANNING_TTL", timedelta(-1)

--- a/flexmeasures/utils/config_defaults.py
+++ b/flexmeasures/utils/config_defaults.py
@@ -110,6 +110,7 @@ class Config(object):
     FLEXMEASURES_MENU_LISTED_VIEW_ICONS: Dict[str, str] = {}
     FLEXMEASURES_MENU_LISTED_VIEW_TITLES: Dict[str, str] = {}
     FLEXMEASURES_LP_SOLVER: str = "cbc"
+    FLEXMEASURES_JOB_TTL: timedelta = timedelta(days=1)
     FLEXMEASURES_PLANNING_HORIZON: timedelta = timedelta(hours=2 * 24)
     FLEXMEASURES_PLANNING_TTL: timedelta = timedelta(
         days=7


### PR DESCRIPTION
After that let Reds remove the job if it needs memory.

This is to keep our Redis memory from growing large with intensive usage by services.
