### PR TITLE
Check for Python files during packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,6 @@ __pycache__
 notebooks/.ipynb_checkpoints/
 
 flexmeasures/ui/static/documentation
-flexmeasures/development_config.py
-flexmeasures/testing_config.py
 documentation/img/screenshot_*
 migrations/dumps
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 def load_requirements(use_case):
@@ -26,13 +26,14 @@ setup(
     tests_require=load_requirements("test"),
     setup_requires=["pytest-runner", "setuptools_scm"],
     use_scm_version={"local_scheme": "no-local-version"},  # handled by setuptools_scm
-    packages=["flexmeasures"],
+    packages=find_packages(),  # will include *.py files and some other types
     include_package_data=True,  # now setuptools_scm adds all files under source control
     entry_points={
         "console_scripts": [
             "flexmeasures=flexmeasures.utils.app_utils:flexmeasures_cli"
         ],
     },
+    license="Apache2.0",
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",

--- a/to_pypi.sh
+++ b/to_pypi.sh
@@ -44,7 +44,7 @@
 NUM_PY_FILES_IN_FM=$(git status --porcelain flexmeasures | grep '??.*\.py' | wc -l)
 if [ $NUM_PY_FILES_IN_FM -gt 0 ]; then
     PY_FILES_IN_FM=$(git status --porcelain flexmeasures | grep '??.*\.py')
-    echo """[TO_PYPI] The following python files are not under git control but would be packaged anyways:
+    echo """[TO_PYPI] The following python files are not under git control but would be packaged anyways (unless explicitly excluded, e.g. in MANIFEST.in):
 
 $PY_FILES_IN_FM
 


### PR DESCRIPTION
My research showed me that we cannot prevent with automation that Python files that are (accidentally) present in the flexmeasures package would be distributed. 

I added logic to our to_pypi script, so that we can be aware of this. I also added a --dry-run flag for testing the packaging like I just did.

Technically, setuptools also includes a few other filetypes aside from all Python files it finds in the package (and setuptools_scm then adds all others which are under git control), but I'm not sure which. I tried .txt, .cfg, .conf, .pyc but none of these would be added.