### PR TITLE
Ci/test multiple python versions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_version: [ '3.8', '3.7', '3.6' ]
+        py_version: [ '3.10', '3.9', '3.8' ]
     name: "Test (on Python ${{ matrix.py_version }})"
     steps:
       - uses: actions/setup-python@v2

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -17,14 +17,14 @@ jobs:
   test:
     needs: check
     runs-on: ubuntu-latest
-    #strategy:  # TODO: make work with pre-commit
-    #  matrix:
-    #    python-version: [ '3.8', '3.6' ]
-    name: "Test (on Python3.8)"
+    strategy:
+      matrix:
+        py_version: [ '3.8', '3.7', '3.6' ]
+    name: "Test (on Python ${{ matrix.py_version }})"
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.py_version }}
       - uses: actions/checkout@v2
       - run: ci/SETUP.sh
       - run: make test

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_version: [ '3.10', '3.9', '3.8' ]
+        py_version: [ '3.8', '3.9' ]
     name: "Test (on Python ${{ matrix.py_version }})"
     steps:
       - uses: actions/setup-python@v2

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -18,6 +18,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         py_version: [ '3.8', '3.7', '3.6' ]
     name: "Test (on Python ${{ matrix.py_version }})"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ run-local:
 	python run-local.py
 
 test:
-	make install-for-dev
+	make install-for-test
 	pytest
 
 # ---- Documentation ---
@@ -31,6 +31,10 @@ install: install-deps install-flexmeasures
 
 install-for-dev:
 	make freeze-deps
+	pip-sync requirements/app.txt requirements/dev.txt requirements/test.txt
+	make install-flexmeasures
+
+install-for-test:
 	pip-sync requirements/app.txt requirements/dev.txt requirements/test.txt
 	make install-flexmeasures
 

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ setup(
     keywords=["smart grid", "renewables", "balancing", "forecasting", "scheduling"],
     python_requires=">=3.7.1",  # not enforced, just info
     install_requires=load_requirements("app"),
-    tests_require=load_requirements("test"),
-    setup_requires=["pytest-runner", "setuptools_scm"],
+    setup_requires=["setuptools_scm"],
     use_scm_version={"local_scheme": "no-local-version"},  # handled by setuptools_scm
     packages=find_packages(),  # will include *.py files and some other types
     include_package_data=True,  # now setuptools_scm adds all files under source control

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email="nicolas@seita.nl",
     url="https://github.com/seitabv/flexmeasures",
     keywords=["smart grid", "renewables", "balancing", "forecasting", "scheduling"],
-    python_requires=">=3.7.1",  # not enforced, just info
+    python_requires=">=3.8",  # not enforced, just info
     install_requires=load_requirements("app"),
     setup_requires=["setuptools_scm"],
     use_scm_version={"local_scheme": "no-local-version"},  # handled by setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(
     license="Apache2.0",
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Finally activating the possibility to run tests on multiple Python versions.

I've chosen to run on exactly what requirements/*.txt currently has, so no `make freeze-deps`. This means tests will fail exactly like they would fail on your PC.