### PR TITLE
Merge search and collect

### DIFF
--- a/flexmeasures/api/v1/implementations.py
+++ b/flexmeasures/api/v1/implementations.py
@@ -199,7 +199,7 @@ def collect_connection_and_value_groups(
 
         # Get the power values
         # TODO: fill NaN for non-existing values
-        power_bdf_dict: Dict[str, tb.BeliefsDataFrame] = Power.collect(
+        power_bdf_dict: Dict[str, tb.BeliefsDataFrame] = Power.search(
             old_sensor_names=sensor_names,
             event_starts_after=start,
             event_ends_before=end,

--- a/flexmeasures/data/models/planning/utils.py
+++ b/flexmeasures/data/models/planning/utils.py
@@ -82,7 +82,7 @@ def get_prices(
     # Look for the applicable market sensor
     sensor = get_market(sensor)
 
-    price_bdf: tb.BeliefsDataFrame = Price.collect(
+    price_bdf: tb.BeliefsDataFrame = Price.search(
         sensor.name,
         event_starts_after=query_window[0],
         event_ends_before=query_window[1],

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -302,7 +302,7 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
     @classmethod
     def search(
         cls,
-        sensor: Union[Sensor, int],
+        sensor: Union[Sensor, int, str, List[Union[Sensor, int, str]]],
         event_starts_after: Optional[datetime_type] = None,
         event_ends_before: Optional[datetime_type] = None,
         beliefs_after: Optional[datetime_type] = None,
@@ -318,79 +318,12 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
         most_recent_beliefs_only: bool = False,
         most_recent_events_only: bool = False,
         most_recent_only: bool = False,  # deprecated
-    ) -> tb.BeliefsDataFrame:
-        """Search all beliefs about events for a given sensor.
-
-        :param sensor: search only this sensor
-        :param event_starts_after: only return beliefs about events that start after this datetime (inclusive)
-        :param event_ends_before: only return beliefs about events that end before this datetime (inclusive)
-        :param beliefs_after: only return beliefs formed after this datetime (inclusive)
-        :param beliefs_before: only return beliefs formed before this datetime (inclusive)
-        :param horizons_at_least: only return beliefs with a belief horizon equal or greater than this timedelta (for example, use timedelta(0) to get ante knowledge time beliefs)
-        :param horizons_at_most: only return beliefs with a belief horizon equal or less than this timedelta (for example, use timedelta(0) to get post knowledge time beliefs)
-        :param source: search only beliefs by this source (pass the DataSource, or its name or id) or list of sources
-        :param user_source_ids: Optional list of user source ids to query only specific user sources
-        :param source_types: Optional list of source type names to query only specific source types *
-        :param exclude_source_types: Optional list of source type names to exclude specific source types *
-        :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon)
-        :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start)
-
-        * If user_source_ids is specified, the "user" source type is automatically included (and not excluded).
-          Somewhat redundant, though still allowed, is to set both source_types and exclude_source_types.
-        """
-        # todo: deprecate the 'most_recent_only' argument in favor of 'most_recent_beliefs_only' (announced v0.8.0)
-        most_recent_beliefs_only = tb_utils.replace_deprecated_argument(
-            "most_recent_only",
-            most_recent_only,
-            "most_recent_beliefs_only",
-            most_recent_beliefs_only,
-            required_argument=False,
-        )
-        parsed_sources = parse_source_arg(source)
-        source_criteria = get_source_criteria(
-            cls, user_source_ids, source_types, exclude_source_types
-        )
-        return cls.search_session(
-            session=db.session,
-            sensor=sensor,
-            event_starts_after=event_starts_after,
-            event_ends_before=event_ends_before,
-            beliefs_after=beliefs_after,
-            beliefs_before=beliefs_before,
-            horizons_at_least=horizons_at_least,
-            horizons_at_most=horizons_at_most,
-            source=parsed_sources,
-            most_recent_beliefs_only=most_recent_beliefs_only,
-            most_recent_events_only=most_recent_events_only,
-            custom_filter_criteria=source_criteria,
-        )
-
-    @classmethod
-    def collect(
-        cls,
-        sensors: Union[Sensor, int, str, List[Union[Sensor, int, str]]],
-        event_starts_after: Optional[datetime_type] = None,
-        event_ends_before: Optional[datetime_type] = None,
-        horizons_at_least: Optional[timedelta] = None,
-        horizons_at_most: Optional[timedelta] = None,
-        beliefs_after: Optional[datetime_type] = None,
-        beliefs_before: Optional[datetime_type] = None,
-        source: Optional[
-            Union[DataSource, List[DataSource], int, List[int], str, List[str]]
-        ] = None,
-        user_source_ids: Union[
-            int, List[int]
-        ] = None,  # None is interpreted as all sources
-        source_types: Optional[List[str]] = None,
-        exclude_source_types: Optional[List[str]] = None,
-        most_recent_beliefs_only: bool = True,
-        most_recent_events_only: bool = False,
         resolution: Union[str, timedelta] = None,
         sum_multiple: bool = True,
     ) -> Union[tb.BeliefsDataFrame, Dict[str, tb.BeliefsDataFrame]]:
-        """Collect beliefs about events for the given sensors.
+        """Search all beliefs about events for the given sensors.
 
-        :param sensors: search only these sensors, identified by their instance or id (both unique) or name (non-unique)
+        :param sensor: search only these sensors, identified by their instance or id (both unique) or name (non-unique)
         :param event_starts_after: only return beliefs about events that start after this datetime (inclusive)
         :param event_ends_before: only return beliefs about events that end before this datetime (inclusive)
         :param beliefs_after: only return beliefs formed after this datetime (inclusive)
@@ -410,39 +343,47 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
            Somewhat redundant, though still allowed, is to set both source_types and exclude_source_types.
         ** Note that timely-beliefs converts string resolutions to datetime.timedelta objects (see https://github.com/SeitaBV/timely-beliefs/issues/13).
         """
-
-        # sanity check
-        assert sensors, "no sensors passed"
+        # todo: deprecate the 'most_recent_only' argument in favor of 'most_recent_beliefs_only' (announced v0.8.0)
+        most_recent_beliefs_only = tb_utils.replace_deprecated_argument(
+            "most_recent_only",
+            most_recent_only,
+            "most_recent_beliefs_only",
+            most_recent_beliefs_only,
+            required_argument=False,
+        )
 
         # convert to list
-        if not isinstance(sensors, list):
-            sensors = [sensors]
+        sensors = [sensor] if not isinstance(sensor, list) else sensor
 
         # convert from sensor names to sensors
         sensor_names = [s for s in sensors if isinstance(s, str)]
         if sensor_names:
-            sensors = [s for s in sensors if not isinstance(s, str)]
+            sensors = [s for s in sensor if not isinstance(s, str)]
             sensors_from_names = Sensor.query.filter(
                 Sensor.name.in_(sensor_names)
             ).all()
             sensors.extend(sensors_from_names)
 
+        parsed_sources = parse_source_arg(source)
+        source_criteria = get_source_criteria(
+            cls, user_source_ids, source_types, exclude_source_types
+        )
+
         bdf_dict = {}
         for sensor in sensors:
-            bdf = cls.search(
-                sensor,
+            bdf = cls.search_session(
+                session=db.session,
+                sensor=sensor,
                 event_starts_after=event_starts_after,
                 event_ends_before=event_ends_before,
-                horizons_at_least=horizons_at_least,
-                horizons_at_most=horizons_at_most,
                 beliefs_after=beliefs_after,
                 beliefs_before=beliefs_before,
-                source=source,
-                user_source_ids=user_source_ids,
-                source_types=source_types,
-                exclude_source_types=exclude_source_types,
+                horizons_at_least=horizons_at_least,
+                horizons_at_most=horizons_at_most,
+                source=parsed_sources,
                 most_recent_beliefs_only=most_recent_beliefs_only,
                 most_recent_events_only=most_recent_events_only,
+                custom_filter_criteria=source_criteria,
             )
             if resolution is not None:
                 bdf = bdf.resample_events(

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -303,7 +303,7 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
     def search(
         cls,
         sensors: Union[Sensor, int, str, List[Union[Sensor, int, str]]],
-        sensor: Sensor,  # deprecated
+        sensor: Sensor = None,  # deprecated
         event_starts_after: Optional[datetime_type] = None,
         event_ends_before: Optional[datetime_type] = None,
         beliefs_after: Optional[datetime_type] = None,
@@ -350,7 +350,6 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
             sensor,
             "sensors",
             sensors,
-            required_argument=False,
         )
         # todo: deprecate the 'most_recent_only' argument in favor of 'most_recent_beliefs_only' (announced v0.8.0)
         most_recent_beliefs_only = tb_utils.replace_deprecated_argument(

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -586,7 +586,7 @@ class TimedValue(object):
         return query.filter(*belief_timing_criteria, *source_criteria)
 
     @classmethod
-    def collect(
+    def search(
         cls,
         old_sensor_names: Union[str, List[str]],
         event_starts_after: Optional[datetime_type] = None,

--- a/flexmeasures/data/models/time_series.py
+++ b/flexmeasures/data/models/time_series.py
@@ -303,7 +303,7 @@ class TimedBelief(db.Model, tb.TimedBeliefDBMixin):
     def search(
         cls,
         sensors: Union[Sensor, int, str, List[Union[Sensor, int, str]]],
-        sensor: Union[Sensor, int],  # deprecated
+        sensor: Sensor,  # deprecated
         event_starts_after: Optional[datetime_type] = None,
         event_ends_before: Optional[datetime_type] = None,
         beliefs_after: Optional[datetime_type] = None,

--- a/flexmeasures/data/queries/analytics.py
+++ b/flexmeasures/data/queries/analytics.py
@@ -176,7 +176,7 @@ def get_prices_data(
     market_name = "" if market_sensor is None else market_sensor.name
 
     # Get price data
-    price_bdf: tb.BeliefsDataFrame = Price.collect(
+    price_bdf: tb.BeliefsDataFrame = Price.search(
         [market_name],
         event_starts_after=query_window[0],
         event_ends_before=query_window[1],
@@ -194,7 +194,7 @@ def get_prices_data(
         metrics["realised_unit_price"] = np.NaN
 
     # Get price forecast
-    price_forecast_bdf: tb.BeliefsDataFrame = Price.collect(
+    price_forecast_bdf: tb.BeliefsDataFrame = Price.search(
         [market_name],
         event_starts_after=query_window[0],
         event_ends_before=query_window[1],
@@ -264,7 +264,7 @@ def get_weather_data(
             sensor_names = [sensor.name for sensor in closest_sensors]
 
             # Get weather data
-            weather_bdf_dict: Dict[str, tb.BeliefsDataFrame] = Weather.collect(
+            weather_bdf_dict: Dict[str, tb.BeliefsDataFrame] = Weather.search(
                 sensor_names,
                 event_starts_after=query_window[0],
                 event_ends_before=query_window[1],
@@ -281,7 +281,7 @@ def get_weather_data(
                 )
 
             # Get weather forecasts
-            weather_forecast_bdf_dict: Dict[str, tb.BeliefsDataFrame] = Weather.collect(
+            weather_forecast_bdf_dict: Dict[str, tb.BeliefsDataFrame] = Weather.search(
                 sensor_names,
                 event_starts_after=query_window[0],
                 event_ends_before=query_window[1],

--- a/flexmeasures/data/services/resources.py
+++ b/flexmeasures/data/services/resources.py
@@ -477,7 +477,7 @@ class Resource:
             )
 
             # Query the sensors
-            resource_data: Dict[str, tb.BeliefsDataFrame] = sensor_type.collect(
+            resource_data: Dict[str, tb.BeliefsDataFrame] = sensor_type.search(
                 old_sensor_names=list(names_of_resource_sensors),
                 event_starts_after=start,
                 event_ends_before=end,

--- a/flexmeasures/data/tests/test_queries.py
+++ b/flexmeasures/data/tests/test_queries.py
@@ -43,7 +43,7 @@ def test_collect_power(db, app, query_start, query_end, num_values, setup_test_d
     wind_device_1 = Sensor.query.filter_by(name="wind-asset-1").one_or_none()
     data = Power.query.filter(Power.sensor_id == wind_device_1.id).all()
     print(data)
-    bdf: tb.BeliefsDataFrame = Power.collect(wind_device_1.name, query_start, query_end)
+    bdf: tb.BeliefsDataFrame = Power.search(wind_device_1.name, query_start, query_end)
     print(bdf)
     assert (
         bdf.index.names[0] == "event_start"
@@ -89,7 +89,7 @@ def test_collect_power_resampled(
     db, app, query_start, query_end, resolution, num_values, setup_test_data
 ):
     wind_device_1 = Sensor.query.filter_by(name="wind-asset-1").one_or_none()
-    bdf: tb.BeliefsDataFrame = Power.collect(
+    bdf: tb.BeliefsDataFrame = Power.search(
         wind_device_1.name, query_start, query_end, resolution=resolution
     )
     print(bdf)
@@ -206,7 +206,7 @@ def test_multiplication_with_both_empty_dataframe():
 def test_simplify_index(setup_test_data, check_empty_frame):
     """Check whether simplify_index retains the event resolution."""
     wind_device_1 = Sensor.query.filter_by(name="wind-asset-1").one_or_none()
-    bdf: tb.BeliefsDataFrame = Power.collect(
+    bdf: tb.BeliefsDataFrame = Power.search(
         wind_device_1.name,
         datetime(2015, 1, 1, tzinfo=pytz.utc),
         datetime(2015, 1, 2, tzinfo=pytz.utc),

--- a/flexmeasures/data/tests/test_queries.py
+++ b/flexmeasures/data/tests/test_queries.py
@@ -226,7 +226,7 @@ def test_query_beliefs(setup_beliefs):
     bdfs = [
         TimedBelief.search(sensor, source=source),
         TimedBelief.search(sensor.id, source=source),
-        TimedBelief.collect(sensor.name, source=source),
+        TimedBelief.search(sensor.name, source=source),
         sensor.search_beliefs(source=source),
         tb.BeliefsDataFrame(sensor.beliefs),  # doesn't allow filtering
     ]


### PR DESCRIPTION
As desired from https://github.com/SeitaBV/flexmeasures/pull/260#issuecomment-986798702, we're immediately merging the new `TimedBelief.collect` method with the existing `TimedBelief.search` method. This also entails renaming all occurences of `TimedValue.collect` to become `TimedValue.search`, in order to safeguard the goal of PR #260.